### PR TITLE
fix(mobile menu) ways being fixed mobile menu always being clickable

### DIFF
--- a/packages/client/src/components/menu/MenuList.tsx
+++ b/packages/client/src/components/menu/MenuList.tsx
@@ -34,7 +34,8 @@ const StyledList = styled.ul<IStyledList>`
           opacity: 1;
           transition: opacity 200ms 0ms;
         }`
-        : `& { 
+        : `& {
+          display:none;
           opacity: 0;
           transition: opacity 200ms 0ms;
         }`};


### PR DESCRIPTION
Mobile menu is no longer always clickable. This solves the mobile mode 
"learn more" expandable sections do not expand