### PR TITLE
fix(mobile homepage) fix spacing within intro text

### DIFF
--- a/packages/client/src/pages/index.tsx
+++ b/packages/client/src/pages/index.tsx
@@ -74,6 +74,8 @@ const Tagline = styled(Stack)`
     letter-spacing: 0.15rem;
     font-weight: 500;
     line-height: 1.56;
+    margin-top: 8px;
+    margin-bottom: 32px;
   }
 `;
 


### PR DESCRIPTION
Intro text has had the space inbetween itself reduced and the space 
between it and the first image increased.