### PR TITLE
fix(report) typo fix

### DIFF
--- a/packages/client/src/components/report/ReportIntro.tsx
+++ b/packages/client/src/components/report/ReportIntro.tsx
@@ -87,7 +87,7 @@ const ReportIntro: React.FC<IReportIntro> = ({ isLoading }) => (
         <Center>
           <Title>
             <p>web accessibility report</p>
-            <h1>Thanks for Making the web accessible for everybody</h1>
+            <h1>Thanks for making the web accessible for everybody</h1>
           </Title>
         </Center>
       </>


### PR DESCRIPTION
Entering text had a capitalization that did not need to be there