### PR TITLE
fix(mobile homepage) centering buttons for mobile

### DIFF
--- a/packages/client/src/components/tool-overview/ToolOverview.tsx
+++ b/packages/client/src/components/tool-overview/ToolOverview.tsx
@@ -105,7 +105,9 @@ const ToolOverview: React.FC<IToolOverview> = ({ data, type }) => {
                 <p>{details[1]}</p>
                 <Banner text={details[2]} />
               </Stack>
+              <MobileCenter>
               {Object.keys(ctaData).length !== 0 && <CTA {...ctaData} />}
+              </MobileCenter>
             </InfoWrapper>
           </Center>
           <Center>


### PR DESCRIPTION
Centering "find out more" button on the mobile homepage